### PR TITLE
css hotfix for createItem

### DIFF
--- a/autolog-ui/src/components/CreateItem/CreateItem.css
+++ b/autolog-ui/src/components/CreateItem/CreateItem.css
@@ -4,7 +4,7 @@
     display: flex;
     flex-grow: 1;
     flex-direction: column;
-    overflow: hidden;
+    overflow-x: hidden;
 }
 
 .create-item .content {

--- a/autolog-ui/src/components/CreateItem/CreateItem.jsx
+++ b/autolog-ui/src/components/CreateItem/CreateItem.jsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import './CreateItem.css'
-import Search from "../../assets/Search.png"
 import ItemContext from '../../contexts/items';
 import { useContext, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -8,7 +7,6 @@ import { motion } from 'framer-motion';
 import InventoryContext from '../../contexts/inventory';
 import Form from '../Form/Form';
 import DropdownCategory from '../DropdownCategory/DropdownCategory';
-import FormInput from '../FormInput/FormInput';
 import TextArea from '../TextArea/TextArea';
 import ButtonAction from '../Button/ButtonAction';
 


### PR DESCRIPTION
- [x] now overflow is not hidden in createItem page as page has too much content for small screens
- [x] overflow hidden for x scroll